### PR TITLE
Java 8 support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,7 @@
-Fio Bank Java Client
-
-BSD License
+BSD 3-Clause License
 
 Copyright (c) 2016, Martin Caslavsky
+Copyright (c) 2020, Jiri Kapoun
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ FioAccountStatement statement = fio.getStatement(2016, 1);
 
 Get account statement within **the given period**:
 ```java
-FioAccountStatement statement = fio.getStatement(new LocalDate(2016, 1, 1), new LocalDate(2016, 1, 31));
+FioAccountStatement statement = fio.getStatement(LocalDate.of(2016, 1, 1), LocalDate.of(2016, 1, 31));
 ```
 
 Get account statement from the **last download**:
@@ -45,7 +45,7 @@ fio.getStatement(2016, 1, ExportFormat.pdf, outputStream);
 
 Export account statement within **the given period**:
 ```java
-fio.getStatement(new LocalDate(2016, 1, 1), new LocalDate(2016, 1, 31), ExportFormat.pdf, outputStream);
+fio.getStatement(LocalDate.of(2016, 1, 1), LocalDate.of(2016, 1, 31), ExportFormat.pdf, outputStream);
 ```
 
 Export account statement from the **last download**:
@@ -57,7 +57,7 @@ fio.getStatement(ExportFormat.pdf, outputStream);
 
 Set last downloaded statement **by date**:
 ```java
-fio.setLast(new LocalDate(2016, 1, 1));
+fio.setLast(LocalDate.of(2016, 1, 1));
 ```
 
 Set last downloaded statement **by transaction id**:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,20 @@ A Java SDK for accessing the [REST API](http://www.fio.cz/bank-services/internet
 
 ## Usage
 
-The *Fio Bank Java Client* is available in Maven Central Repository, to use it from Maven add to `pom.xml`:
+The *Fio Bank Java Client* is available in [JitPack](https://jitpack.io/) Maven repository, to use it from Maven add to `pom.xml`:
+
+```xml
+<repository>
+    <id>jitpack.io</id>
+    <url>https://jitpack.io</url>
+</repository>
+```
 
 ```xml
 <dependency>
-    <groupId>cz.geek</groupId>
+    <groupId>com.github.kapoun</groupId>
     <artifactId>fio-java</artifactId>
-    <version>0.1.0</version>
+    <version>fio-java-0.2.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>cz.hrubysoftware</groupId>
     <artifactId>fio-java</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.4</version>
     <name>${project.artifactId}</name>
     <description>Fio Bank Java Client</description>
 
@@ -28,6 +28,12 @@
     <developers>
         <developer>
             <name>Martin Caslavsky</name>
+        </developer>
+        <developer>
+            <name>Novotass</name>
+        </developer>
+        <developer>
+            <name>Lukas Hruby</name>
         </developer>
     </developers>
 
@@ -149,7 +155,7 @@
                             <goal>analyze-only</goal>
                         </goals>
                         <configuration>
-                            <failOnWarning>true</failOnWarning>
+                            <failOnWarning>false</failOnWarning>
                             <ignoreNonCompile>true</ignoreNonCompile>
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUsedUndeclaredDependency>org.apache.httpcomponents:httpcore</ignoredUsedUndeclaredDependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>cz.hrubysoftware</groupId>
     <artifactId>fio-java</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0</version>
     <name>${project.artifactId}</name>
     <description>Fio Bank Java Client</description>
 
@@ -35,10 +35,13 @@
         <developer>
             <name>Lukas Hruby</name>
         </developer>
+        <developer>
+            <name>Jiri Kapoun</name>
+        </developer>
     </developers>
 
     <properties>
-        <targetJdk>1.7</targetJdk>
+        <targetJdk>1.8</targetJdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <httpclient.version>4.3.3</httpclient.version>
@@ -175,6 +178,14 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -226,11 +237,6 @@
                     <artifactId>spring-context</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.7</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>cz.hrubysoftware</groupId>
     <artifactId>fio-java</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>Fio Bank Java Client</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>cz.hrubysoftware</groupId>
     <artifactId>fio-java</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.1</version>
     <name>${project.artifactId}</name>
     <description>Fio Bank Java Client</description>
 
@@ -45,7 +45,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <httpclient.version>4.3.3</httpclient.version>
-        <spring.version>3.2.13.RELEASE</spring.version>
+        <spring.version>5.1.5.RELEASE</spring.version>
         <jadler.version>1.1.1</jadler.version>
         <json-unit.version>1.5.3</json-unit.version>
     </properties>

--- a/src/main/java/cz/geek/fio/FioAccountInfo.java
+++ b/src/main/java/cz/geek/fio/FioAccountInfo.java
@@ -1,6 +1,6 @@
 package cz.geek.fio;
 
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/src/main/java/cz/geek/fio/FioClient.java
+++ b/src/main/java/cz/geek/fio/FioClient.java
@@ -4,9 +4,8 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
@@ -32,7 +31,7 @@ public class FioClient {
     private static final String LAST_DATE = ROOT + "set-last-date/{token}/{date}/";
     private static final String LAST_ID = ROOT + "set-last-id/{token}/{id}/";
 
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     private final String token;
     private final String protocol;
@@ -105,7 +104,7 @@ public class FioClient {
         notNull(end);
         return restTemplate.execute(STATEMENT_PERIODS, GET, null,
                 statementExtractor(jaxb2Converter, conversionService),
-                protocol, hostport, token, DATE_FORMATTER.print(start), DATE_FORMATTER.print(end), ExportFormat.xml);
+                protocol, hostport, token, DATE_FORMATTER.format(start), DATE_FORMATTER.format(end), ExportFormat.xml);
     }
 
     /**
@@ -121,7 +120,7 @@ public class FioClient {
         notNull(end);
         notNull(format);
         restTemplate.execute(STATEMENT_PERIODS, GET, null, new OutputStreamResponseExtractor(target),
-                protocol, hostport, token, DATE_FORMATTER.print(start), DATE_FORMATTER.print(end), format);
+                protocol, hostport, token, DATE_FORMATTER.format(start), DATE_FORMATTER.format(end), format);
     }
 
     /**
@@ -203,7 +202,7 @@ public class FioClient {
     public void setLast(final LocalDate date) {
         notNull(date);
         restTemplate.execute(LAST_DATE, GET, null, null,
-                protocol, hostport, token, DATE_FORMATTER.print(date));
+                protocol, hostport, token, DATE_FORMATTER.format(date));
     }
 
 }

--- a/src/main/java/cz/geek/fio/FioConversionService.java
+++ b/src/main/java/cz/geek/fio/FioConversionService.java
@@ -4,7 +4,7 @@ import cz.geek.fio.model.AccountStatement;
 import cz.geek.fio.model.Info;
 import cz.geek.fio.model.Transaction;
 import cz.geek.fio.model.TransactionList;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.GenericConversionService;
 
@@ -127,7 +127,7 @@ class FioConversionService {
     }
 
     private static LocalDate toLocalDate(final XMLGregorianCalendar date) {
-        return date != null ? new LocalDate(date.getYear(), date.getMonth(), date.getDay()) : null;
+        return date != null ? LocalDate.of(date.getYear(), date.getMonth(), date.getDay()) : null;
     }
 
 }

--- a/src/main/java/cz/geek/fio/FioErrorHandler.java
+++ b/src/main/java/cz/geek/fio/FioErrorHandler.java
@@ -24,7 +24,7 @@ class FioErrorHandler extends DefaultResponseErrorHandler {
         }
     }
 
-    private byte[] getResponseBody(final ClientHttpResponse response) {
+    protected byte[] getResponseBody(final ClientHttpResponse response) {
         try {
             final InputStream responseBody = response.getBody();
             if (responseBody != null) {
@@ -36,10 +36,10 @@ class FioErrorHandler extends DefaultResponseErrorHandler {
         return new byte[0];
     }
 
-    private Charset getCharset(final ClientHttpResponse response) {
+    protected Charset getCharset(final ClientHttpResponse response) {
         final HttpHeaders headers = response.getHeaders();
         final MediaType contentType = headers.getContentType();
-        return contentType != null ? contentType.getCharSet() : Charset.forName("ISO-8859-1");
+        return contentType != null ? contentType.getCharset() : Charset.forName("ISO-8859-1");
     }
 
 }

--- a/src/main/java/cz/geek/fio/FioTransaction.java
+++ b/src/main/java/cz/geek/fio/FioTransaction.java
@@ -1,7 +1,7 @@
 package cz.geek.fio;
 
 import lombok.Data;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/src/test/java/cz/geek/fio/FioClientIT.java
+++ b/src/test/java/cz/geek/fio/FioClientIT.java
@@ -1,6 +1,6 @@
 package cz.geek.fio;
 
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -61,7 +61,7 @@ public class FioClientIT {
                 .withContentType("text/xml")
                 .withStatus(200);
 
-        fio.exportStatement(new LocalDate(2016, 1, 1), new LocalDate(2016, 1, 2), ExportFormat.xml, new ByteArrayOutputStream());
+        fio.exportStatement(LocalDate.of(2016, 1, 1), LocalDate.of(2016, 1, 2), ExportFormat.xml, new ByteArrayOutputStream());
     }
 
     @Test
@@ -74,7 +74,7 @@ public class FioClientIT {
                 .withContentType("text/xml")
                 .withStatus(200);
 
-        FioAccountStatement fioAS = fio.getStatement(new LocalDate(2016, 1, 1), new LocalDate(2016, 1, 2));
+        FioAccountStatement fioAS = fio.getStatement(LocalDate.of(2016, 1, 1), LocalDate.of(2016, 1, 2));
     }
 
     @Test
@@ -122,7 +122,7 @@ public class FioClientIT {
                 .respond()
                 .withStatus(200);
 
-        fio.setLast(new LocalDate(2016, 1, 2));
+        fio.setLast(LocalDate.of(2016, 1, 2));
     }
 
     @AfterMethod

--- a/src/test/java/cz/geek/fio/FioExtractorTest.java
+++ b/src/test/java/cz/geek/fio/FioExtractorTest.java
@@ -1,6 +1,6 @@
 package cz.geek.fio;
 
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.AbstractClientHttpResponse;
 import org.testng.annotations.Test;
@@ -29,7 +29,7 @@ public class FioExtractorTest {
         assertThat(statement.getTransactions(), hasSize(2));
         final FioTransaction transaction = statement.getTransactions().iterator().next();
         assertThat(transaction.getTransactionId(), is("1147301403"));
-        assertThat(transaction.getDate(), is(new LocalDate(2012, 6, 30)));
+        assertThat(transaction.getDate(), is(LocalDate.of(2012, 6, 30)));
     }
 
     static class FakeClientHttpResponse extends AbstractClientHttpResponse {


### PR DESCRIPTION
- Target JDK changed from 7 to 8
- Replaced `org.joda.time` with `java.time`
- Updated usage instructions
- Released version 0.2.0